### PR TITLE
Add animated parallax background

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,13 +46,14 @@
       100% { background-position: 0 300px; }
     }
 
-    #desktop-bg-container { /* Stars background */
+    #desktop-bg-container { /* Parallax & star background */
       position: fixed;
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
       pointer-events: none;
+      overflow: hidden;
       z-index: -1; /* Ensure it's behind everything */
     }
 

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,66 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 
+// --- Background Visuals ---
+const PARALLAX_SETS = [
+  [
+    'assets/Parallax Backgrounds/back.png',
+    'assets/Parallax Backgrounds/middle.png',
+    'assets/Parallax Backgrounds/front.png',
+  ],
+  [
+    'assets/RetroWindowsGUI/Windows_Example_Main.png',
+    'assets/Parallax Backgrounds/middle.png',
+    'assets/Parallax Backgrounds/front.png',
+  ],
+];
+
+const ParallaxBackground: React.FC = () => {
+  const [index, setIndex] = useState(0);
+  const refs = useRef<HTMLDivElement[]>([]);
+  useEffect(() => {
+    let frame = 0;
+    let anim: number;
+    const animate = () => {
+      frame += 0.5;
+      refs.current.forEach((el, i) => {
+        const speed = (i + 1) * 0.2;
+        el.style.backgroundPosition = `${-frame * speed}px 0`;
+      });
+      anim = requestAnimationFrame(animate);
+    };
+    anim = requestAnimationFrame(animate);
+    const interval = setInterval(() => setIndex((i) => (i + 1) % PARALLAX_SETS.length), 15000);
+    return () => {
+      cancelAnimationFrame(anim);
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', zIndex: -1 }}>
+      {PARALLAX_SETS[index].map((src, i) => (
+        <div
+          key={i}
+          ref={(el) => {
+            if (el) refs.current[i] = el;
+          }}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: `url(${src})`,
+            backgroundRepeat: 'repeat-x',
+            backgroundSize: 'cover',
+            willChange: 'background-position',
+            pointerEvents: 'none',
+            zIndex: i,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
 // --- Sound & Music Implementation ---
 let currentMusic: HTMLAudioElement | null = null;
 // const activeSounds: HTMLAudioElement[] = []; // Optional: for managing multiple SFX instances
@@ -518,6 +578,11 @@ const App: React.FC = () => {
 const container = document.getElementById('root');
 if (container) { createRoot(container).render(<App />); }
 else { console.error('Failed to find the root element'); }
+
+const bgContainer = document.getElementById('desktop-bg-container');
+if (bgContainer) {
+  createRoot(bgContainer).render(<ParallaxBackground />);
+}
 // Ensure the Open CoAIexicon button has its icon
 const InGameScreenWithIcon: React.FC<React.ComponentProps<typeof InGameScreen>> = (props) => {
     const originalOnNavigate = props.onNavigate;


### PR DESCRIPTION
## Summary
- create `ParallaxBackground` component that cycles through layered images
- mount the new background under `#desktop-bg-container`
- allow the container to hide overflow

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6868c464d0bc8320afacd53236b7ece9